### PR TITLE
feat: add support for rg

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ in the excellent
 [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons).
 
 Handles color codes as well, using the icon colors from the aforementioned
-library. Intended to take in output from [fd](https://github.com/sharkdp/fd), to
+library. Intended to take in output from [fd](https://github.com/sharkdp/fd) or
+[rg](https://github.com/BurntSushi/ripgrep), to
 then be used as input for [fzf-lua](https://github.com/ibhagwan/fzf-lua) in
 Neovim.
 
@@ -15,7 +16,7 @@ or `fzf` directly would feel much snappier. I concluded (correctly) that this is
 because of the extra processing `fzf-lua` is doing to, amongst other things,
 prepend the file icon. By using a custom `fzf-lua` action that invokes `fd` and
 pipes the results through this binary, you still get the file icons, but with
-the snapiness of running `fd`/`fzf` directly.
+the snapiness of running `fd`/`fzf` directly. Same benefits for `rg` as well.
 
 You could use this project in Neovim using `fzf-lua` as follows:
 
@@ -30,6 +31,18 @@ local function fzf_files()
 end
 
 vim.keymap.set('n', '<C-p>', fzf_files)
+
+local function fzf_live_grep()
+  fzf.fzf_live(
+    'rg --column --line-number --no-heading --color=always --smart-case -- <query> | /path/to/file-web-devicon', {
+    actions = fzf.defaults.actions.files,
+    prompt = 'Rg> ',
+    fzf_opts = { ['--nth'] = 2, ['--delimiter'] = fzf.utils.nbsp },
+    previewer = 'builtin',
+  })
+end
+
+vim.keymap.set('n', '<C-s>', fzf_live_grep)
 ```
 
 _Note_: This project has been tested only on MacOS. I don't know whether it will


### PR DESCRIPTION
For live grep, I use rg like: `rg --column --line-number --no-heading --color=always --smart-case -- <query>` which has color.

Added logic to grab the path for the icon while filtering out the ASCII color codes and keeping everything performant.

<img width="1202" alt="image" src="https://github.com/MaartenStaa/file-web-devicons/assets/30526747/dd5a3e39-3afe-4630-a628-7c232497a8b2">

<img width="1222" alt="image" src="https://github.com/MaartenStaa/file-web-devicons/assets/30526747/d6c5681e-d259-4037-b0ee-2d94fe114d1f">

<img width="1388" alt="image" src="https://github.com/MaartenStaa/file-web-devicons/assets/30526747/5b880a56-e554-45f9-b838-7c6276ab0433">
